### PR TITLE
bugfix: sync cmdb assets to oneterm failed

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -40,7 +40,7 @@ auth:
         value: authorization
 
 cmdb:
-  url: http://host/api/v0.1
+  url: http://cmdb-api:5000/api/v0.1
 
 secretKey: 'xW2FAUfgffjmerTEBXADmURDOQ43ojLN'
 


### PR DESCRIPTION
bugfix: sync cmdb assets to oneterm failed
修复由于配置文件cmdb.url信息错误导致同步cmdb资源到oneterm失败的问题